### PR TITLE
Support running reports with dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     fs,
     jsonlite,
     orderly,
-    outpack (>= 0.1.3),
+    outpack (>= 0.1.5),
     yaml
 Suggests:
     jsonvalidate (>= 1.4.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     fs,
     jsonlite,
     orderly,
-    outpack (>= 0.1.1),
+    outpack (>= 0.1.2),
     yaml
 Suggests:
     jsonvalidate (>= 1.4.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     fs,
     jsonlite,
     orderly,
-    outpack (>= 0.1.2),
+    outpack (>= 0.1.3),
     yaml
 Suggests:
     jsonvalidate (>= 1.4.0),
@@ -25,5 +25,5 @@ Suggests:
     withr
 Config/testthat/edition: 3
 Remotes:
-    mrc-ide/outpack,
+    mrc-ide/outpack@mrc-3456,
     ropensci/jsonvalidate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,5 +25,5 @@ Suggests:
     withr
 Config/testthat/edition: 3
 Remotes:
-    mrc-ide/outpack@mrc-3456,
+    mrc-ide/outpack,
     ropensci/jsonvalidate

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -214,11 +214,8 @@ resolve_dependency <- function(name, query, parameters, root) {
   id <- outpack::outpack_query(query, parameters, scope,
                                require_unpacked = TRUE, root = root$outpack)
   if (is.na(id)) {
-    ## TODO: this friendlier to the user (mrc-3492)
-    if (is.na(id)) {
-      stop(sprintf("Failed to resolve dependency '%s:%s'",
-                   name, query), call. = FALSE)
-    }
+    stop(sprintf("Failed to resolve dependency '%s:%s'",
+                 name, query), call. = FALSE)
   }
   id
 }

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -205,13 +205,10 @@ check_parameters <- function(parameters, info) {
 
 
 resolve_dependency <- function(name, query, parameters, root) {
-  ## TODO, fails if outpack query is an id!
-  ##
   ## TODO, pass location information through too, and join them into the scope.
-  ##
-  ## TODO: can we limit by being local/not?
   scope <- bquote(name == .(name))
-  outpack::outpack_query(query, parameters, scope, root$outpack)
+  outpack::outpack_query(query, parameters, scope,
+                         require_unpacked = TRUE, root = root$outpack)
 }
 
 

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -87,7 +87,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
     if (!is.null(parameters)) {
       list2env(parameters, envir)
     }
-    outpack::outpack_packet_file_mark(inputs)
+    outpack::outpack_packet_file_mark(inputs, "immutable")
     outpack::outpack_packet_add_custom("orderly", custom_metadata,
                                        custom_metadata_schema())
     for (p in dat$packages) {

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -117,9 +117,10 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
 
 
 orderly_custom_metadata <- function(orderly_yml_dat) {
-  custom_artefacts <- lapply(orderly_yml_dat$artefacts, function(x)
+  custom_artefacts <- lapply(orderly_yml_dat$artefacts, function(x) {
     list(description = scalar(x$description),
-         paths = x$filenames))
+         paths = x$filenames)
+  })
   custom_packages <- orderly_yml_dat$packages %||% character()
   custom_global <- list()
 

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -206,10 +206,21 @@ check_parameters <- function(parameters, info) {
 
 
 resolve_dependency <- function(name, query, parameters, root) {
-  ## TODO, pass location information through too, and join them into the scope.
+  ## TODO, pass location information through too, and join them into
+  ## the scope, but we don't yet really have orderly remotes
+  ## (vimc-6666)
   scope <- bquote(name == .(name))
-  outpack::outpack_query(query, parameters, scope,
-                         require_unpacked = TRUE, root = root$outpack)
+  ## TODO: tell outpack we expect a single value (mrc-3493)
+  id <- outpack::outpack_query(query, parameters, scope,
+                               require_unpacked = TRUE, root = root$outpack)
+  if (is.na(id)) {
+    ## TODO: this friendlier to the user (mrc-3492)
+    if (is.na(id)) {
+      stop(sprintf("Failed to resolve dependency '%s:%s'",
+                   name, query), call. = FALSE)
+    }
+  }
+  id
 }
 
 

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -66,6 +66,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
   parameters <- check_parameters(parameters, dat$parameters)
   inputs <- c("orderly.yml", dat$script, dat$resources, dat$sources)
 
+  dat$depends <- resolve_dependencies(dat$depends, parameters, root)
   custom_metadata <- to_json(orderly_custom_metadata(dat))
 
   expected <- unlist(lapply(dat$artefacts, "[[", "filenames"), FALSE, FALSE)
@@ -97,6 +98,11 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
         sys.source(s, envir = envir)
       }
     })
+    for (i in seq_len(NROW(dat$depends))) {
+      outpack::outpack_packet_use_dependency(dat$depends$id[[i]],
+                                             dat$depends$files[[i]])
+    }
+
     outpack::outpack_packet_run(dat$script, envir)
     check_produced_files(path, expected, outpack::outpack_packet_file_list())
     outpack::outpack_packet_end()
@@ -117,14 +123,28 @@ orderly_custom_metadata <- function(orderly_yml_dat) {
   custom_packages <- orderly_yml_dat$packages %||% character()
   custom_global <- list()
 
+  ## TODO: possibly we should track the queries that resolved
+  ## different dependencies. We do this in orderly but have never used
+  ## this information. It might be better to add this to outpack
+  ## though?
+
   ## Not yet handled here: global, readme
+  if (is.null(orderly_yml_dat$depends)) {
+    depends_files <- NULL
+  } else {
+    depends_files <- unlist(lapply(orderly_yml_dat$depends$files, names))
+  }
   custom_role <- data_frame(
-    path = c("orderly.yml", orderly_yml_dat$script,
+    path = c("orderly.yml",
+             orderly_yml_dat$script,
              orderly_yml_dat$sources,
-             orderly_yml_dat$resources),
-    role = c("orderly_yml", "script",
+             orderly_yml_dat$resources,
+             depends_files),
+    role = c("orderly_yml",
+             "script",
              rep_along("source", orderly_yml_dat$sources),
-             rep_along("resource", orderly_yml_dat$resources)))
+             rep_along("resource", orderly_yml_dat$resources),
+             rep_along("dependency", depends_files)))
 
   list(
     artefacts = custom_artefacts,
@@ -181,4 +201,28 @@ check_parameters <- function(parameters, info) {
   use_default <- setdiff(has_default, names(parameters))
   parameters[use_default] <- lapply(info[use_default], "[[", "default")
   parameters[names(info)]
+}
+
+
+resolve_dependency <- function(name, query, parameters, root) {
+  ## TODO, fails if outpack query is an id!
+  ##
+  ## TODO, pass location information through too, and join them into the scope.
+  ##
+  ## TODO: can we limit by being local/not?
+  scope <- bquote(name == .(name))
+  outpack::outpack_query(query, parameters, scope, root$outpack)
+}
+
+
+resolve_dependencies <- function(depends, parameters, root) {
+  if (is.null(depends)) {
+    return(NULL)
+  }
+  depends$query <- depends$id
+  for (i in seq_len(nrow(depends))) {
+    depends$id[[i]] <- resolve_dependency(depends$name[[i]], depends$query[[i]],
+                                          parameters, root)
+  }
+  depends
 }

--- a/R/read.R
+++ b/R/read.R
@@ -236,11 +236,9 @@ recipe_validate_depend1 <- function(depend, filename) {
                  filename, name),
          call. = FALSE)
   }
+  files <- list_to_character(depend$use)
 
-  data_frame(id = depend$id,
-             name = name,
-             filename = list_to_character(depend$use, FALSE),
-             as = names(depend$use))
+  data_frame(id = depend$id, name = name, files = I(list(files)))
 }
 
 

--- a/inst/outpack-custom.json
+++ b/inst/outpack-custom.json
@@ -54,7 +54,7 @@
                         "type": "string"
                     },
                     "role": {
-                        "enum": ["orderly_yml", "resource", "script", "source"]
+                        "enum": ["orderly_yml", "resource", "script", "source", "dependency"]
                     }
                 }
             }

--- a/tests/testthat/examples/depend/orderly.yml
+++ b/tests/testthat/examples/depend/orderly.yml
@@ -2,7 +2,7 @@ script: script.R
 artefacts:
   staticgraph:
     description: A graph of things
-    filenames: mygraph.png
+    filenames: graph.png
 depends:
   - minimal:
       id: latest

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -311,7 +311,9 @@ test_that("Dependencies can be declared", {
   dat <- orderly_yml_read("depend", file.path(path, "src", "depend"))
   expect_equal(
     dat$depends,
-    data_frame(id = "latest", name = "minimal", files = I(list(c(graph.png = "mygraph.png")))))
+    data_frame(id = "latest",
+               name = "minimal",
+               files = I(list(c(graph.png = "mygraph.png")))))
 })
 
 

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -311,8 +311,7 @@ test_that("Dependencies can be declared", {
   dat <- orderly_yml_read("depend", file.path(path, "src", "depend"))
   expect_equal(
     dat$depends,
-    data.frame(id = "latest", name = "minimal", filename = "mygraph.png",
-               as = "graph.png"))
+    data_frame(id = "latest", name = "minimal", files = I(list(c(graph.png = "mygraph.png")))))
 })
 
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -170,3 +170,12 @@ test_that("can run packet with dependency", {
   expect_true(file.exists(
     file.path(path, "archive", "depend", id2, "graph.png")))
 })
+
+
+test_that("can fail with informative error if dependency not found", {
+  path <- test_prepare_orderly_example(c("minimal", "depend"))
+  env <- new.env()
+  expect_error(
+    orderly_run("depend", root = path, envir = env),
+    "Failed to resolve dependency 'minimal:latest'")
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -154,3 +154,19 @@ test_that("clean parameters given spec", {
   expect_error(check_parameters(list(a = 1, c = 3, d = 4), info),
                "Extra parameters: 'c', 'd'")
 })
+
+
+test_that("can run packet with dependency", {
+  path <- test_prepare_orderly_example(c("minimal", "depend"))
+  env <- new.env()
+  id1 <- orderly_run("minimal", root = path, envir = env)
+  id2 <- orderly_run("depend", root = path, envir = env)
+
+  root <- orderly_root(path, FALSE)
+  meta <- root$outpack$metadata(id2, full = TRUE)
+  expect_equal(meta$depends$id, id1)
+  expect_equal(meta$depends$files[[1]],
+               data_frame(here = "graph.png", there = "mygraph.png"))
+  expect_true(file.exists(
+    file.path(path, "archive", "depend", id2, "graph.png")))
+})


### PR DESCRIPTION
Basic support for running orderly reports with dependencies, using the query DSL in https://github.com/mrc-ide/outpack/pull/15

~Requires https://github.com/mrc-ide/outpack/pull/18 and https://github.com/mrc-ide/outpack/pull/17~

The windows build failure is just gha failing to cope with gert being updated on CRAN, it will resolve in a day or two, but does not matter for this PR