### PR TITLE
Fix issue where dependencies were not being tracked when checking produced files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,5 @@
 ^\.github$
 \.*gcov$
 ^TODO\.md$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -121,6 +121,10 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
       outpack::outpack_packet_use_dependency(dat$depends$id[[i]],
                                              dat$depends$files[[i]])
     }
+    packet <- outpack::outpack_packet_current()
+    lapply(packet$depends, function(dependency) {
+      expected <- c(expected, dependency$files$here)
+    })
 
     ## TODO: if run fails we might not close out the device stack
     ## here, we do need to do that to make things easy for the user.

--- a/orderly2.Rproj
+++ b/orderly2.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -14,7 +14,8 @@ test_prepare_orderly_example <- function(examples, ...) {
     config <- c(config,
                 "global_resources: global")
     fs::dir_create(file.path(tmp, "global"))
-    fs::file_copy("examples/minimal/data.csv", file.path(tmp, "global"))
+    fs::file_copy(test_path("examples/minimal/data.csv"),
+                  file.path(tmp, "global"))
   }
 
   if ("plugin" %in% examples) {
@@ -29,7 +30,7 @@ test_prepare_orderly_example <- function(examples, ...) {
   writeLines(config, file.path(tmp, "orderly_config.yml"))
   fs::dir_create(file.path(tmp, "src"))
   for (i in examples) {
-    fs::dir_copy(file.path("examples", i), file.path(tmp, "src"))
+    fs::dir_copy(test_path("examples", i), file.path(tmp, "src"))
   }
   tmp
 }
@@ -53,4 +54,52 @@ json_to_df <- function(x) {
 
 hash_file <- function(...) {
   outpack:::hash_file(...)
+}
+
+
+test_path <- function(...) {
+  if (basename(getwd()) == "testthat") {
+    file.path(...)
+  } else {
+    testthat::test_path(...)
+  }
+}
+
+
+## Expects dependencies to be a list of name and id (or search query)
+## e.g.
+## list(a = "latest", b = "latest(parameter:x == 2)") # nolint
+## By convention will expect report artefact to be "data.rds" and will
+## map this to "input.rds" in the script.R
+create_random_report <- function(root, name = "data", dependencies = NULL) {
+  report_dir <- fs::dir_create(file.path(root, "src", name))
+  withr::defer_parent(unlink(report_dir, recursive = TRUE))
+
+  yml <- c(
+    "script: script.R",
+    "artefacts:",
+    "  data:",
+    "    description: Random data",
+    "    filenames: data.rds"
+  )
+
+  if (!is.null(dependencies)) {
+    assert_named(dependencies)
+    formatted_depends <- do.call(c, lapply(names(dependencies), function(name) {
+      id <- dependencies[[name]]
+      c(sprintf("  - %s:", name),
+        sprintf("      id: %s", id),
+                "      use:",
+                "        input.rds: data.rds")
+    }))
+    yml <- c(yml, "depends:", formatted_depends)
+    script <- c("x <- readRDS(\"input.rds\")",
+                "saveRDS(x + runif(10), \"data.rds\")")
+  } else {
+    script <- "saveRDS(runif(10), \"data.rds\")"
+  }
+
+  writeLines(yml, file.path(report_dir, "orderly.yml"))
+  writeLines(script, file.path(report_dir, "script.R"))
+  invisible(report_dir)
 }


### PR DESCRIPTION
If we have a setup like
```
/tmp/RtmpQ8SMJI/file3f9221513272c
├── archive
│   └── a
│       └── 20230404-162405-5caf9730
│           ├── data.rds
│           ├── orderly.yml
│           └── script.R
├── draft
│   └── a
├── orderly_config.yml
└── src
    ├── a
    │   ├── orderly.yml
    │   └── script.R
    └── b
        ├── orderly.yml
        └── script.R
```

where `a` just saves out an rds as `data.rds` then b has yml
```
script: script.R
artefacts:
  data:
    description: Random data
    filenames: data.rds
depends:
  - a:
      id: latest
      use:
        input.rds: data.rds
```

And the script

```
x <- readRDS("input.rds")
saveRDS(x + runif(10), "data.rds")
```

When running we get a message "Some extra files found: 'input.rds'"
This is because when running
1. orderly copies dependency from A into working dir as input.rds
2. Runs script saving out data.rds
3. Checks that files on disk in working dir are either from src directory or are artefacts. 

In particular 3. doesn't check for dependencies and so raises the "extra files" message. This doesn't happen for existing dependency test as that just copies the file over so that file is both the dependency and the artefact.

This PR will
* Add test setup (which I want to put in place for testing pulling in dependencies with `usedby` and `uses` queries
* Fix the issue mentioned above

There were a couple of ways we could have got the expected dependency info out, we also have it available in `custom_metadata` or could have read it out when reading the yml. Not sure what is most appropriate here so let me know if you want a bit of a different approach.